### PR TITLE
Update agent documentation to the new CW agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cw_logs_files:
       batch_count: 10000
       batch_size: 1048576
 ```
-The field `name` defines the name of the log entry, that should be unique and the field `args` should contain the specifics of the log configuration as per AWS docs in here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html
+The field `name` defines the name of the log entry, that should be unique and the field `args` should contain the specifics of the log configuration as per AWS docs in here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Install-CloudWatch-Agent.htmlhtml
 
 
 Dependencies


### PR DESCRIPTION
> Important
This reference is for the older CloudWatch Logs agent, which is on the path to deprecation. We strongly recommend that you use the unified CloudWatch agent instead. For more information about that agent, see Collecting metrics and logs from Amazon EC2 instance and on-premises servers with the CloudWatch agent.


Seems the current link is pointing to outdated documentation, so would be good to update it.

Also, not sure the role is up to date, is it installing the deprecated logs agent or the new unified one mentioned in the new docs? (I've just started looking into it, might edit this later) 